### PR TITLE
Fix for uninitialized layerScaleNameAc field in seqData

### DIFF
--- a/PLUGIN/src/tl_mathSeqData.cpp
+++ b/PLUGIN/src/tl_mathSeqData.cpp
@@ -265,7 +265,7 @@ PF_Err tlmath::copyFromArbToSeqData(PF_InData* in_data, PF_OutData* out_data, st
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/camera_rotation",seqDataP->cameraRotationNameAc);
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/resolution",seqDataP->resolutionNameAc);
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/layerPosition",seqDataP->layerPositionNameAc);
-	copyStrFromJsonToSeqData(arbDataJS, "/composition/layerScale",seqDataP->layerGrpNameAc);
+	copyStrFromJsonToSeqData(arbDataJS, "/composition/layerScale",seqDataP->layerScaleNameAc);
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/compResolution",seqDataP->compResolutionNameAc);
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/time_sec",seqDataP->time_secNameAc);
 	copyStrFromJsonToSeqData(arbDataJS, "/composition/time_frame",seqDataP->time_frameNameAc);

--- a/PLUGIN/src/tl_math_io.cpp
+++ b/PLUGIN/src/tl_math_io.cpp
@@ -381,6 +381,7 @@ AppendGlslInput2dText(std::string& newSh,
                      std::string  expr,
                      std::string varStr,
 					 bool*  hasTexture){
+    assert(!varStr.empty());
     const std::size_t found = expr.find(varStr);
 	tlmath_shaders tlms;
     if (found!=std::string::npos){
@@ -393,6 +394,7 @@ static void
 AppendGlslInputFloat(std::string& newSh,
                      std::string  expr,
                 std::string varStr){
+    assert(!varStr.empty());
     const std::size_t found = expr.find(varStr);
 	tlmath_shaders tlms;
     if (found!=std::string::npos){
@@ -403,6 +405,7 @@ static void
 AppendGlslInputVec2d(std::string& newSh,
                      std::string  expr,
                      std::string varStr){
+    assert(!varStr.empty());
     const std::size_t found = expr.find(varStr);
     if (found!=std::string::npos){
 		tlmath_shaders tlms;
@@ -413,6 +416,7 @@ static void
 AppendGlslInputVec3d(std::string& newSh,
                      std::string  expr,
                      std::string varStr){
+    assert(!varStr.empty());
     const std::size_t found = expr.find(varStr);
     if (found!=std::string::npos){
 		tlmath_shaders tlms;
@@ -423,6 +427,7 @@ static void
 AppendGlslInputBool (std::string& newSh,
                      std::string  expr,
                      std::string varStr){
+    assert(!varStr.empty());
     const std::size_t found = expr.find(varStr);
     if (found!=std::string::npos){
 		tlmath_shaders tlms;


### PR DESCRIPTION
Fix for uninitialized layerScaleNameAc field in seqData.

This fixes https://github.com/crazylafo/AE_tl_math/issues/26 in which the uninitialized field causes corrupted glsl code which usually compiles and produces the correct output, but sometimes fails to compile and produces a "shader error" frame.

Also add asserts in AppendGlslInput* which would have caught the problem. Justification: find("") is nonsensical and should never happen.